### PR TITLE
updates invoker after BlobBuilder and ArrayBuffer deprecation

### DIFF
--- a/invoke/invoker/config.xml
+++ b/invoke/invoker/config.xml
@@ -30,4 +30,5 @@ limitations under the License.
         <rim:permit>access_shared</rim:permit>
     </rim:permissions>
     <feature id="blackberry.invoke" required="true" version="1.0.0.0"/>
+    <feature id="blackberry.io" required="true" version="1.0.0.0" />
 </widget>

--- a/invoke/invoker/index.html
+++ b/invoke/invoker/index.html
@@ -22,7 +22,7 @@
 		Include BlackBerry 10 WebWorks JavaScript framework file.
 		When doing an SDK upgrade, always make sure you grab the latest from the SDK/Framework/clientFiles folder.
 	-->
-    <script src="webworks-1.0.1.5.js"></script>
+    <script src="webworks-1.0.0.7.js"></script>
     <script src="invocations.js"></script>
     <link rel="stylesheet" type="text/css" href="jquery/jquery.mobile-1.1.0.min.css" />
     <script src="jquery/jquery-1.7.1.min.js"></script>
@@ -35,7 +35,7 @@
             document.getElementById("adobeReader").onclick = invokeAdobeReader;
             document.getElementById("adobeReaderPdf").onclick = invokeAdobeReaderPdf;
             document.getElementById("userApp").onclick = invokeApp;
-            document.getElementById("pictures").onclick = invokePictures;
+            document.getElementById("pictures").onclick = saveFileInvoke;
         }
         //register ready event after window has loaded
         window.addEventListener("load", function (e) {

--- a/invoke/invoker/invocations.js
+++ b/invoke/invoker/invocations.js
@@ -66,50 +66,33 @@ function invokeApp() {
     }, onSuccess, onError);
 }
 
-//This is an unbound invocation (no target specified): the OS will choose what target to use based on URI
-function invokePictures() {
+function saveFileInvoke () {
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', '/cliffs.jpg', false);
+    xhr.responseType = 'blob';
+
+    xhr.onload = function(e) {
+        blackberry.io.sandbox = false;
+        window.webkitRequestFileSystem(PERSISTENT, 1024 * 1024, function(fs) {
+            fs.root.getFile(blackberry.io.sharedFolder + '/downloads/cliffs.jpg', {create: true}, function(fileEntry) {
+                fileEntry.createWriter(function(writer) {
+
+                writer.onerror = function(e) { alert(e) };
+
+                var blob = new Blob([xhr.response], {type: 'image/jpeg'});
+
+                writer.write(blob);
+
+                }, errorHandler);
+            }, errorHandler);
+        }, errorHandler);
+    }
     
-    downloadPicture();
-    
+    xhr.send();
+
     blackberry.invoke.invoke({
         uri: "file:///accounts/1000/shared/downloads/cliffs.jpg",
     }, onSuccess, onError);
-}
-
-//Supported in HTML5: getting binary data from XHR request
-function downloadPicture() {
-    var xhr = new XMLHttpRequest();
-    xhr.open('GET', "/cliffs.jpg", true);
-    xhr.responseType = 'arraybuffer';
-    
-    xhr.onload = function(e) {
-        if (this.status == 200) {
-            var bb = new window.WebKitBlobBuilder();
-            bb.append(this.response);
-            var blob = bb.getBlob('image/jpeg');
-            saveFile(blob);
-        }
-    };
-    xhr.send();
-}
-
-//This function demonstrates how to use the HTML5 FileSystem API: a .png blob is saved to a URI which is used for invocation
-function saveFile (blob) {
-    function gotFs(fs) {
-        fs.root.getFile("/accounts/1000/shared/downloads/cliffs.jpg", {create: true}, gotFile, errorHandler);
-    }
-
-    function gotFile(fileEntry) {
-        fileEntry.createWriter(gotWriter, errorHandler);
-    }
-
-    function gotWriter(fileWriter) {
-        fileWriter.onerror = function (e) {
-            alert("Failed to write JPEG: " + e.toString());
-        }
-        fileWriter.write(blob);
-    }
-    window.webkitRequestFileSystem(PERSISTENT, 10 * 1024, gotFs, errorHandler);
 }
 
 function errorHandler(fileError) {


### PR DESCRIPTION
Updates the invoker sample application to use Blob constructor instead of Blob builder, and uses arraybufferview instead of arraybuffer

Issue: https://github.com/blackberry/BB10-WebWorks-Samples/issues/8
