### PR TITLE
Copy paste error when describing _top behavior.

### DIFF
--- a/childBrowser/href.html
+++ b/childBrowser/href.html
@@ -25,7 +25,7 @@
 	<p class="desc">The _blank attribute will load a new page in a separate web view.</p>
 
 	<p class="heading">target=_top</p>
-	<p class="desc">This _blank attribute will load a new page in this web view.</p>
+	<p class="desc">This _top attribute will load a new page in this web view.</p>
 
 	<p class="heading">target=_self</p>
 	<p class="desc">The _self attribute will load a child page in this web view.</p>


### PR DESCRIPTION
Just a quick correction to what is most likely a copy/paste error when describing the behavior of clicking on a link using _top.
