### PR TITLE
Adding media query targeting OLED screens

### DIFF
--- a/Built-For-BlackBerry/css/style.css
+++ b/Built-For-BlackBerry/css/style.css
@@ -31,3 +31,11 @@ body, html {
 @media screen and (max-width: 720px) and (max-height: 720px){
 	/*add q10 specific stylings here*/
 }
+
+/* ================================================================ */
+/* 								OLED 								*/
+/* ================================================================ */
+
+@media (-blackberry-display-technology: -blackberry-display-oled) {
+	/* add OLED screen specific styling here */
+}

--- a/Built-For-BlackBerry/css/style.css
+++ b/Built-For-BlackBerry/css/style.css
@@ -37,5 +37,8 @@ body, html {
 /* ================================================================ */
 
 @media (-blackberry-display-technology: -blackberry-display-oled) {
-	/* add OLED screen specific styling here */
+	/* add OLED screen specific styling here 
+	 For more details on how this should be used please read:
+	 http://devblog.blackberry.com/2013/03/blackberry-10-oled-control-coloring-update/
+	*/
 }


### PR DESCRIPTION
This media query allows styling specific to OLED based devices. Note:
this is BlackBerry specific.
