### PR TITLE
Fixed INVOKE_BAD_REQUEST_ERROR when clicking "Open a PDF file in

### DIFF
--- a/invoke/invoker/config.xml
+++ b/invoke/invoker/config.xml
@@ -29,4 +29,8 @@ limitations under the License.
     <feature id="blackberry.invoke" required="true" version="1.0.0.0"/>
     <feature id="blackberry.invoke.card" />
     <feature id="blackberry.io" required="true" version="1.0.0.0" />
+	
+    <rim:permissions>
+        <rim:permit>access_shared</rim:permit>
+    </rim:permissions>
 </widget>


### PR DESCRIPTION
Fixed INVOKE_BAD_REQUEST_ERROR when pressing "Open a PDF file in Adobe Reader" by adding access_shared permission in config.xml.
