### PR TITLE
fix errors.

### DIFF
--- a/Invocation/Invokable/www/js/app.js
+++ b/Invocation/Invokable/www/js/app.js
@@ -47,18 +47,18 @@ var Application = {
             // Fires "after" styling is applied and "after" the screen is inserted in the DOM
             ondomready: function(element, id) {
                 blackberry.event.addEventListener("invoked", function(invocationInfo) {
-                    printToLog("Handler start . . .");
+                    console.log("Handler start . . .");
                     if (invocationInfo.target) {
-                        console.log(nvocationInfo.target);
+                        console.log(invocationInfo.target);
                     }
                     if (invocationInfo.type) {
-                        console.log(nvocationInfo.type);
+                        console.log(invocationInfo.type);
                     }
                     if (invocationInfo.action) {
-                        console.log(nvocationInfo.action);
+                        console.log(invocationInfo.action);
                     }
                     if (invocationInfo.data) {
-                        console.log(nvocationInfo.data);
+                        console.log(invocationInfo.data);
                     }
                 });
 


### PR DESCRIPTION
I don't think this sample can work since printToLog is not defined and it has typo mistakes.
and Here's my question:

1, Why register the listener in ondomready? why not in deviceready event handler  or bind events function ?
2, After invoked, do I need to call bb.pushScreen() to set up the display screen ?
3, If I invoke my app as a card, can I swipe right to back to the parent document without change anything on screen ? 

after tried for about 1 hour I still can't get the code run. when I call blackberry.invoke.invoke(request,func,func) it tolds me successfully invoked but I never get it in "invoked" event,the event never fired.
I don't know why.
